### PR TITLE
Publish to npmjs

### DIFF
--- a/.github/workflows/release-npm-package.yml
+++ b/.github/workflows/release-npm-package.yml
@@ -73,4 +73,4 @@ jobs:
         run: bun run build
 
       - name: Publish Package
-        run: bun publish --no-build --access=public
+        run: bunx npm publish --provenance --no-build --access=public


### PR DESCRIPTION
This pull request updates the npm package release workflow to improve security and modernize the publishing process.

**Workflow permissions updates:**

* Changed the permission from `packages: write` to `id-token: write` in `.github/workflows/release-npm-package.yml` to support OIDC authentication for publishing.

**Publishing process modernization:**

* Updated the publish step to use `bunx npm publish` with provenance and public access flags, replacing the previous `bun publish` command and removing the use of the `BUN_PUBLISH_TOKEN` environment variable.