### PR TITLE
feat: support dynamic command registration in Application class and update guides

### DIFF
--- a/examples/tui-app/index.ts
+++ b/examples/tui-app/index.ts
@@ -21,6 +21,9 @@ import { StatusCommand } from "./commands/status.ts";
 
 class ExampleApp extends TuiApplication {
     constructor() {
+        // Pass commands in the constructor for simple cases.
+        // For dynamic registration (e.g., after async initialization),
+        // omit `commands` here and call `this.registerCommands([...])` later.
         super({
             name: "example",
             version: "1.0.0",

--- a/guides/00-getting-started.md
+++ b/guides/00-getting-started.md
@@ -91,6 +91,9 @@ class MyCLI extends Application {
 await new MyCLI().run();
 ```
 
+> **Tip**: Commands can also be registered after construction using `app.registerCommands([...])`. 
+> This is useful when commands depend on async initialization or runtime configuration.
+
 Run it:
 
 ```bash

--- a/guides/01-hello-world.md
+++ b/guides/01-hello-world.md
@@ -96,6 +96,9 @@ bun src/index.ts greet help
 - The `execute()` method handles the logic
 - `Application` ties everything together
 
+> **Note**: Commands can also be registered after construction using `app.registerCommands([...])`.
+> This is useful when commands depend on async initialization. See the main README for details.
+
 ## Next Steps
 
 → [Guide 2: Adding Options](02-adding-options.md)

--- a/guides/03-multiple-commands.md
+++ b/guides/03-multiple-commands.md
@@ -156,6 +156,9 @@ src/
 - Handle errors gracefully
 - Use consistent option patterns across commands
 
+> **Tip**: For dynamic command registration (e.g., when commands depend on async services),
+> you can omit `commands` from the config and call `app.registerCommands([...])` after construction.
+
 ## Next Steps
 
 → [Guide 4: Subcommands](04-subcommands.md)

--- a/guides/04-subcommands.md
+++ b/guides/04-subcommands.md
@@ -201,6 +201,9 @@ src/
 - Each subcommand has its own options
 - Help is automatically nested (`db help`, `db migrate help`)
 
+> **Tip**: Commands (including parent commands with subcommands) can be registered dynamically
+> using `app.registerCommands([...])` after construction.
+
 ## Next Steps
 
 → [Guide 5: Interactive TUI](05-interactive-tui.md)

--- a/guides/README.md
+++ b/guides/README.md
@@ -86,6 +86,10 @@ EOF
 bun src/index.ts hello --name "Developer"
 ```
 
+> **Tip**: Commands can also be registered after construction using `app.registerCommands([...])`. 
+> This is useful when commands depend on async initialization or runtime configuration.
+> See the main README for details.
+
 ## Prerequisites
 
 - [Bun](https://bun.sh)

--- a/packages/create-terminatui/template/src/index.ts
+++ b/packages/create-terminatui/template/src/index.ts
@@ -9,6 +9,9 @@ export class MyApp extends TuiApplication {
     protected override defaultMode = "opentui" as const;
 
     constructor() {
+        // Pass commands in the constructor for simple cases.
+        // For dynamic registration (e.g., after async initialization),
+        // omit `commands` here and call `this.registerCommands([...])` later.
         super({
             name: MyApp.appName,
             displayName: "My TUI App",


### PR DESCRIPTION
This pull request introduces support for dynamic command registration in the `Application` class, allowing commands to be registered after construction. This enables scenarios where commands depend on async initialization or runtime configuration, and improves flexibility for CLI and TUI applications. The change is documented throughout the codebase and guides, and maintains backward compatibility with the original API.

**Core feature: Dynamic command registration**

* Added `registerCommands(commands: Command[])` method to `Application`, allowing commands to be registered after construction. Ensures commands are only registered once and throws if attempted multiple times.
* Modified `ApplicationConfig` so `commands` is now optional, and updated constructor logic to handle both static and dynamic registration. [[1]](diffhunk://#diff-d126c9e98592c29f44206f52fcc881cc11e32379108ba35735a646e374730d17L61-R65) [[2]](diffhunk://#diff-d126c9e98592c29f44206f52fcc881cc11e32379108ba35735a646e374730d17L149-R223)
* Added a runtime check in `runFromArgs()` to ensure commands are registered before running, with a clear error message if not.

**Documentation and guides**

* Updated main README and all guides to document dynamic command registration, including usage examples and tips for when to use this pattern. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R203-R208) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L228-R234) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R264-R294) [[4]](diffhunk://#diff-02cf691b5c5b46700f7af33e568982b2e2ff942762d9e039f2fc5724cd8deb04R94-R96) [[5]](diffhunk://#diff-2216c28e9548abe5a9e27427c767d10ed45be367dc2b1cff415397642572fd2cR99-R101) [[6]](diffhunk://#diff-a4142633f6e1f07f288fd70138b845ef3ee3a2363a10b502d62c07d35d46740bR159-R161) [[7]](diffhunk://#diff-ebfabadf3bc33cbf48278f1f0b6ae06a8859850d50374cb1b214e4c4ca12f0a7R204-R206) [[8]](diffhunk://#diff-649d189a8231566360ee2e0c865d203c86b590987d36383cebce29b06c3d7e2dR89-R92)
* Added extensive code examples and comments in guides and template files to illustrate both static and dynamic registration patterns. [[1]](diffhunk://#diff-1e61a16578ae8de480901c13c054161ffb825aff500a07fb65217d55cb10e622R405-R458) [[2]](diffhunk://#diff-a8370504257fa92c2983949fe2da11fd6b8705495ce92fa442edbefaefce8931R24-R26) [[3]](diffhunk://#diff-5ef159410bdfedc2c16b2e7cda0acc47a2120c7b8535bef266bd5fb65eea966bR12-R14)

**Backward compatibility and API clarity**

* Preserved support for passing `commands` in the constructor config, with clear documentation and examples for both approaches. [[1]](diffhunk://#diff-d126c9e98592c29f44206f52fcc881cc11e32379108ba35735a646e374730d17R94) [[2]](diffhunk://#diff-d126c9e98592c29f44206f52fcc881cc11e32379108ba35735a646e374730d17R104-R122)
* Ensured that passing `commands: []` still registers built-in commands for compatibility.

These changes make the framework more flexible for advanced use cases, while maintaining ease of use for simple applications.